### PR TITLE
Improved CSS to match vscode color themes

### DIFF
--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -52,45 +52,69 @@ const style = document.createElement('style');
 document.head.appendChild(style);
 style.innerText = `
 svg {
-	
+	fill: var(--theme-foreground);
 }
 .root text,
 .root tspan {
 	font: 12px Arial;
 }
+/* Line between the matches */
 .root path {
 	fill-opacity: 0;
 	stroke-width: 2px;
 	stroke: var(--theme-foreground);
 }
+/* Start and end circles */
 .root circle {
-	fill: var(--theme-menu-hover-background);
+	fill: var(--theme-background);
 	stroke-width: 2px;
 	stroke: var(--theme-foreground);
 }
+/* Foreground for any matches */
 .anchor text,
 .any-character text {
 	fill: var(--theme-foreground);
 }
+/* Background for any matches */
 .anchor rect,
 .any-character rect {
-	fill: var(--theme-menu-hover-background);
+	fill: var(--theme-background);
+	stroke-width: 1px;
+	stroke: var(--vscode-focusBorder);
 }
+/* Foreground for escape char */
 .escape text,
-.charset-escape text,
-.literal text {
-	fill: var(--theme-foreground);
+.charset-escape text {
+	fill: var(--vscode-menu-foreground);
 }
+/* Background for escape char */
 .escape rect,
 .charset-escape rect {
-	fill: #bada55;
+	fill: var(--vscode-menu-background);
+	stroke-width: 1px;
+	stroke: var(--vscode-menu-border);
 }
+/* Forground for literal */
+.literal text {
+	fill: var(--vscode-menu-selectionForeground);
+}
+/* Background for literal */
 .literal rect {
-	fill: var(--theme-button-background);
+	fill: var(--vscode-menu-selectionBackground);
+	stroke-width: 1px;
+	stroke: var(--vscode-menu-selectionBorder);
 }
+/* Background for char class */
 .charset .charset-box {
-	fill: var(--theme-menu-hover-background);
+	fill: var(--theme-menu-background);
+	stroke-width: 1px;
+	stroke: var(--vscode-focusBorder);
 }
+/* Label text for char class */
+.charset .charset-label {
+	fill: var(--theme-foreground);
+}
+/* Label text for char class or group */
 .subexp .subexp-label tspan,
 .charset .charset-label tspan,
 .match-fragment .repeat-label tspan {
@@ -104,7 +128,7 @@ svg {
 	dominant-baseline: text-after-edge;
 }
 .subexp .subexp-box {
-	stroke: #908c83;
+	stroke: var(--theme-foreground);
 	stroke-dasharray: 6, 2;
 	stroke-width: 2px;
 	fill-opacity: 0;


### PR DESCRIPTION
resolve: #7

Since the current color scheme can impair visibility in some vscode color themes, I will modify the CSS definitions to match as many vscode color themes as possible.

It is unfortunate for me that the original Regexper theme color of green will be compromised, but for my part, I thought it was important to preserve visibility.


https://github.com/user-attachments/assets/a2a613bb-b921-4115-9d0f-c66cc7ede0ab

